### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -53,12 +53,12 @@ minimized for the use cases that requires ``process_request``.
 Documentation
 -------------
 
-The full documentation is at https://djangocms-redirect.readthedocs.org.
+The full documentation is at https://djangocms-redirect.readthedocs.io.
 
 Installation
 ------------
 
-See https://djangocms-redirect.readthedocs.org/en/latest/installation.html
+See https://djangocms-redirect.readthedocs.io/en/latest/installation.html
 
 Features
 --------


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.