### PR TITLE
Django new style middleware compatibility

### DIFF
--- a/djangocms_redirect/middleware.py
+++ b/djangocms_redirect/middleware.py
@@ -8,17 +8,25 @@ from django.contrib.sites.shortcuts import get_current_site
 from django.core.cache import cache
 from django.core.exceptions import ImproperlyConfigured
 
+try:
+    from django.utils.deprecation import MiddlewareMixin
+except ImportError:
+    MiddlewareMixin = object
+
 from .models import Redirect
 
 
-class RedirectMiddleware(object):
+class RedirectMiddleware(MiddlewareMixin):
 
     # Defined as class-level attributes to be subclassing-friendly.
     response_gone_class = http.HttpResponseGone
     response_redirect_class = http.HttpResponseRedirect
     response_permanent_redirect_class = http.HttpResponsePermanentRedirect
 
-    def __init__(self):
+    def __init__(self, *args, **kwargs):
+        if MiddlewareMixin != object:
+            super(RedirectMiddleware, self).__init__(*args, **kwargs)
+
         if not apps.is_installed('django.contrib.sites'):
             raise ImproperlyConfigured(
                 'You cannot use RedirectFallbackMiddleware when '


### PR DESCRIPTION
This patch provides compatibility with Django 1.10+ MIDDLEWARE setting (https://docs.djangoproject.com/en/1.10/topics/http/middleware/#upgrading-middleware).