### PR TITLE
Fix issue https://github.com/nephila/djangocms-redirect/issues/8

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -11,3 +11,6 @@ Contributors
 ------------
 
 * Iacopo Spalletti <i.spalletti@nephila.it>
+* Giovanni Bottalico <g.bottalico@frankhood.it>
+* Gaetano D'Onghia <g.donghia@frankhood.it>
+* Nicola Ciccarone <n.ciccarone@frankhood.it>

--- a/djangocms_redirect/middleware.py
+++ b/djangocms_redirect/middleware.py
@@ -10,7 +10,7 @@ from django.core.exceptions import ImproperlyConfigured
 from django.utils.deprecation import MiddlewareMixin
 
 from .models import Redirect
-
+from .utils import get_key_from_path_and_site
 
 class RedirectMiddleware(MiddlewareMixin):
 
@@ -32,7 +32,7 @@ class RedirectMiddleware(MiddlewareMixin):
         full_path = request.get_full_path()
         current_site = get_current_site(request)
         r = None
-        key = '{0}_{1}'.format(full_path, settings.SITE_ID)
+        key = get_key_from_path_and_site(full_path, settings.SITE_ID)
         cached_redirect = cache.get(key)
         if not cached_redirect:
             try:

--- a/djangocms_redirect/middleware.py
+++ b/djangocms_redirect/middleware.py
@@ -12,6 +12,7 @@ from django.utils.deprecation import MiddlewareMixin
 from .models import Redirect
 from .utils import get_key_from_path_and_site
 
+
 class RedirectMiddleware(MiddlewareMixin):
 
     # Defined as class-level attributes to be subclassing-friendly.

--- a/djangocms_redirect/models.py
+++ b/djangocms_redirect/models.py
@@ -53,5 +53,6 @@ class Redirect(models.Model):
 @receiver(post_save, sender=Redirect)
 @receiver(post_delete, sender=Redirect)
 def clear_redirect_cache(**kwargs):
-    key = '{0}_{1}'.format(kwargs['instance'].old_path, kwargs['instance'].site_id)
+    from .utils import get_key_from_path_and_site
+    key = get_key_from_path_and_site(kwargs['instance'].old_path, kwargs['instance'].site_id)
     cache.delete(key)

--- a/djangocms_redirect/utils.py
+++ b/djangocms_redirect/utils.py
@@ -1,10 +1,11 @@
 # -*- coding: utf-8 -*-
 import hashlib
 
+
 def get_key_from_path_and_site(path, site_id):
     '''
     cache key has to be < 250 chars to avoid memcache.Client.MemcachedKeyLengthError
-    The best algoritm is SHA-224 whose output (224 chars) respects this limitations  
+    The best algoritm is SHA-224 whose output (224 chars) respects this limitations
     '''
     key = '{}_{}'.format(path, site_id)
     key = hashlib.sha224(key.encode('utf-8')).hexdigest()

--- a/djangocms_redirect/utils.py
+++ b/djangocms_redirect/utils.py
@@ -1,0 +1,9 @@
+# -*- coding: utf-8 -*-
+
+def get_key_from_path_and_site(path, site_id):
+    key = '{0}_{1}'.format(path, site_id)
+    # FIX memcache.Client.MemcachedKeyLengthError --------------------------------------------------
+    import hashlib
+    key = hashlib.sha224(key.encode('utf-8')).hexdigest()
+    # /FIX memcache.Client.MemcachedKeyLengthError -------------------------------------------------
+    return key

--- a/djangocms_redirect/utils.py
+++ b/djangocms_redirect/utils.py
@@ -1,9 +1,11 @@
 # -*- coding: utf-8 -*-
+import hashlib
 
 def get_key_from_path_and_site(path, site_id):
-    key = '{0}_{1}'.format(path, site_id)
-    # FIX memcache.Client.MemcachedKeyLengthError --------------------------------------------------
-    import hashlib
+    '''
+    cache key has to be < 250 chars to avoid memcache.Client.MemcachedKeyLengthError
+    The best algoritm is SHA-224 whose output (224 chars) respects this limitations  
+    '''
+    key = '{}_{}'.format(path, site_id)
     key = hashlib.sha224(key.encode('utf-8')).hexdigest()
-    # /FIX memcache.Client.MemcachedKeyLengthError -------------------------------------------------
     return key

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -3,4 +3,5 @@ coverage
 flake8>=2.1.0
 tox>=1.7.0
 djangocms-helper
+python-memcached
 

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, print_function, unicode_literals
 
+from django.test.utils import override_settings
 from djangocms_redirect.models import Redirect
 
 from .base import BaseRedirectTest
@@ -38,8 +39,12 @@ class TestRedirect(BaseRedirectTest):
         )
 
         response = self.client.get(pages[1].get_absolute_url())
-        self.assertEqual(response.status_code, 302)
-        self.assertRedirects(response, redirect.new_path, status_code=302)
+        print("pages[0].get_absolute_url() : ",pages[0].get_absolute_url())
+        print("pages[1].get_absolute_url() : ",pages[1].get_absolute_url())
+        print("request.url : ",pages[1].get_absolute_url())
+        print("response.url : ",response.url)
+        #self.assertEqual(response.status_code, 302)
+        self.assertRedirects(response, redirect.new_path)#, status_code=302)
 
     def test_410_redirect(self):
         pages = self.get_pages()
@@ -87,9 +92,41 @@ class TestRedirect(BaseRedirectTest):
             new_path=pages[0].get_absolute_url(),
             response_code='301',
         )
+        
 
         response = self.client.get(pages[1].get_absolute_url())
         self.assertRedirects(response, redirect.new_path, status_code=301)
         redirect.delete()
         response2 = self.client.get(pages[1].get_absolute_url())
         self.assertEqual(response2.status_code, 200)
+
+
+try:
+    import memcache
+except ImportError:
+    pass
+else:
+    @override_settings(
+        CACHES = {
+            'default': {
+                'BACKEND': 'django.core.cache.backends.memcached.MemcachedCache',
+                'LOCATION': '127.0.0.1:11211',
+            }
+        }
+    )
+    class TestMemcacheRedirect(BaseRedirectTest):
+                
+        def test_fix_memcache_MemcachedKeyLengthError(self):
+            """
+            Fixes https://github.com/nephila/djangocms-redirect/issues/8
+            Using an url > 250 chars memcache go in overflow -> memcache.Client.MemcachedKeyLengthError
+            """
+            url = "/?"+('x'*250) # url > 250 chars
+            response = self.client.get(url)
+            try:
+                self.assertRedirects(response, "/en"+url, status_code=302, target_status_code=200)
+            except memcache.Client.MemcachedKeyLengthError:
+                self.fail("memcache.Client.MemcachedKeyLengthError raised")
+
+            
+

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -39,11 +39,7 @@ class TestRedirect(BaseRedirectTest):
         )
 
         response = self.client.get(pages[1].get_absolute_url())
-        print("pages[0].get_absolute_url() : ",pages[0].get_absolute_url())
-        print("pages[1].get_absolute_url() : ",pages[1].get_absolute_url())
-        print("request.url : ",pages[1].get_absolute_url())
-        print("response.url : ",response.url)
-        #self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.status_code, 302)
         self.assertRedirects(response, redirect.new_path)#, status_code=302)
 
     def test_410_redirect(self):


### PR DESCRIPTION
Hi, 
This pull request fixes [this issue](https://github.com/nephila/djangocms-redirect/issues/8)

I have written the patch and a test.

n.b.
I preferred to move the creation of the key to be used in the cache to an external function to have a single point of failure (you can find it in the `utils.py` file).
Infact after the first version of the patch the other tests were not successful because a similar function that created that key was called by a method of the Redirect model, too

Hope it helps




