### PR TITLE
Ignore querystring when matching redirect objects

### DIFF
--- a/djangocms_redirect/middleware.py
+++ b/djangocms_redirect/middleware.py
@@ -39,7 +39,8 @@ class RedirectMiddleware(MiddlewareMixin):
         ):
             return response
 
-        full_path = request.get_full_path()
+        full_path, part, querystring = request.get_full_path().partition('?')
+        querystring = '%s%s' % (part, querystring)
         current_site = get_current_site(request)
         r = None
         key = '{0}_{1}'.format(full_path, settings.SITE_ID)
@@ -75,9 +76,13 @@ class RedirectMiddleware(MiddlewareMixin):
         if cached_redirect['redirect'] == '':
             return self.response_gone_class()
         if cached_redirect['status_code'] == '302':
-            return self.response_redirect_class(cached_redirect['redirect'])
+            return self.response_redirect_class(
+                '%s%s' % (cached_redirect['redirect'], querystring)
+            )
         elif cached_redirect['status_code'] == '301':
-            return self.response_permanent_redirect_class(cached_redirect['redirect'])
+            return self.response_permanent_redirect_class(
+                '%s%s' % (cached_redirect['redirect'], querystring)
+            )
         elif cached_redirect['status_code'] == '410':
             return self.response_gone_class()
 

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -41,6 +41,20 @@ class TestRedirect(BaseRedirectTest):
         self.assertEqual(response.status_code, 302)
         self.assertRedirects(response, redirect.new_path, status_code=302)
 
+    def test_querystring_redirect(self):
+        pages = self.get_pages()
+
+        redirect = Redirect.objects.create(
+            site=self.site_1,
+            old_path=pages[1].get_absolute_url(),
+            new_path=pages[0].get_absolute_url(),
+            response_code='302',
+        )
+
+        response = self.client.get(pages[1].get_absolute_url() + '?Some_query_param')
+        self.assertEqual(response.status_code, 302)
+        self.assertRedirects(response, redirect.new_path + '?Some_query_param', status_code=302)
+
     def test_410_redirect(self):
         pages = self.get_pages()
 


### PR DESCRIPTION
By removing the querystring before matcing redirect and readding before returning the new URL 