### PR TITLE
Ignore querystring when matching redirect objects

### DIFF
--- a/djangocms_redirect/middleware.py
+++ b/djangocms_redirect/middleware.py
@@ -27,7 +27,8 @@ class RedirectMiddleware(object):
 
     def do_redirect(self, request):
 
-        full_path = request.get_full_path()
+        full_path, part, querystring = request.get_full_path().partition('?')
+        querystring = '%s%s' % (part, querystring)
         current_site = get_current_site(request)
         r = None
         key = '{0}_{1}'.format(full_path, settings.SITE_ID)
@@ -60,9 +61,13 @@ class RedirectMiddleware(object):
         if cached_redirect['redirect'] == '':
             return self.response_gone_class()
         if cached_redirect['status_code'] == '302':
-            return self.response_redirect_class(cached_redirect['redirect'])
+            return self.response_redirect_class(
+                '%s%s' % (cached_redirect['redirect'], querystring)
+            )
         elif cached_redirect['status_code'] == '301':
-            return self.response_permanent_redirect_class(cached_redirect['redirect'])
+            return self.response_permanent_redirect_class(
+                '%s%s' % (cached_redirect['redirect'], querystring)
+            )
         elif cached_redirect['status_code'] == '410':
             return self.response_gone_class()
 

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -62,6 +62,19 @@ class TestRedirect(BaseRedirectTest):
         self.assertEqual(response.status_code, 302)
         self.assertRedirects(response, redirect.new_path, status_code=302)
 
+    def test_querystring_redirect(self):
+
+        redirect = Redirect.objects.create(
+            site=self.site_1,
+            old_path=str(self.page1.get_absolute_url()),
+            new_path='/en/',
+            response_code='302',
+        )
+
+        response = self.client.get('/en/test-page/?Some_query_param')
+        self.assertEqual(response.status_code, 302)
+        self.assertRedirects(response, redirect.new_path + '?Some_query_param', status_code=302)
+
     def test_410_redirect(self):
 
         Redirect.objects.create(


### PR DESCRIPTION
By removing the querystring before matcing redirect and readding before returning the new URL