### PR TITLE
Add support to match unquoted strings as redirect old path

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -10,7 +10,8 @@ History
 * Drop compatibility with Django < 1.11
 * Drop compatibility with django CMS < 3.6
 * Move to django-app-helper
-* Add subpath matching (#21)
+* Add subpath matching
+* Add support to match unquoted strings as redirect old path
 
 0.3.1 (2019-07-13)
 ++++++++++++++++++

--- a/djangocms_redirect/middleware.py
+++ b/djangocms_redirect/middleware.py
@@ -11,6 +11,7 @@ from django.core.cache import cache
 from django.core.exceptions import ImproperlyConfigured
 from django.db.models import Q
 from django.utils.deprecation import MiddlewareMixin
+from django.utils.http import urlunquote_plus
 
 from .models import Redirect
 from .utils import get_key_from_path_and_site
@@ -37,26 +38,33 @@ class RedirectMiddleware(MiddlewareMixin):
         ):
             return response
 
-        full_path, part, querystring = request.get_full_path().partition('?')
-        full_path_slash, __, __ = request.get_full_path(force_append_slash=True).partition('?')
+        full_path_quoted, part, querystring = request.get_full_path().partition('?')
+        possible_paths = [full_path_quoted]
+        if urlunquote_plus(full_path_quoted) != full_path_quoted:
+            possible_paths.append(urlunquote_plus(full_path_quoted))
+        if not settings.APPEND_SLASH and not request.path.endswith('/'):
+            try:
+                full_path_slash, __, __ = request.get_full_path(
+                    force_append_slash=True
+                ).partition('?')
+                possible_paths.extend([urlunquote_plus(full_path_slash), full_path_slash])
+            except TypeError:
+                pass
         querystring = '%s%s' % (part, querystring)
         current_site = get_current_site(request)
         r = None
-        key = get_key_from_path_and_site(full_path, settings.SITE_ID)
+        key = get_key_from_path_and_site(full_path_quoted, settings.SITE_ID)
         cached_redirect = cache.get(key)
-        filters = dict(site=current_site, old_path=full_path)
-        filters_slash = dict(site=current_site, old_path=full_path_slash)
         if not cached_redirect:
-            try:
-                r = Redirect.objects.get(**filters)
-            except Redirect.DoesNotExist:
-                if not settings.APPEND_SLASH and not request.path.endswith('/'):
-                    try:
-                        r = Redirect.objects.get(**filters_slash)
-                    except Redirect.DoesNotExist:
-                        pass
-            if not r:
-                r = self._match_substring(full_path)
+            for path in possible_paths:
+                filters = dict(site=current_site, old_path=path)
+                try:
+                    r = Redirect.objects.get(**filters)
+                    break
+                except Redirect.DoesNotExist:
+                    r = self._match_substring(path)
+                    if r:
+                        break
             cached_redirect = {
                 'site': settings.SITE_ID,
                 'redirect': r.new_path if r else None,

--- a/djangocms_redirect/middleware.py
+++ b/djangocms_redirect/middleware.py
@@ -40,16 +40,17 @@ class RedirectMiddleware(MiddlewareMixin):
 
         full_path_quoted, part, querystring = request.get_full_path().partition('?')
         possible_paths = [full_path_quoted]
-        if urlunquote_plus(full_path_quoted) != full_path_quoted:
-            possible_paths.append(urlunquote_plus(full_path_quoted))
+        full_path_unquoted = urlunquote_plus(full_path_quoted)
+        if full_path_unquoted != full_path_quoted:
+            possible_paths.append(urlunquote_plus(full_path_unquoted))
         if not settings.APPEND_SLASH and not request.path.endswith('/'):
-            try:
-                full_path_slash, __, __ = request.get_full_path(
-                    force_append_slash=True
-                ).partition('?')
-                possible_paths.extend([urlunquote_plus(full_path_slash), full_path_slash])
-            except TypeError:
-                pass
+            full_path_slash, __, __ = request.get_full_path(
+                force_append_slash=True
+            ).partition('?')
+            possible_paths.append(full_path_slash)
+            full_path_slash_unquoted = urlunquote_plus(full_path_slash)
+            if full_path_slash_unquoted != full_path_slash:
+                possible_paths.append(full_path_slash_unquoted)
         querystring = '%s%s' % (part, querystring)
         current_site = get_current_site(request)
         r = None

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -226,7 +226,7 @@ class TestRedirect(BaseRedirectTest):
                 response_code='301',
             )
 
-            with self.assertNumQueries(6):
+            with self.assertNumQueries(4):
                 response = self.client.get(pages[1].get_absolute_url().rstrip('/'))
             self.assertEqual(404, response.status_code)
 

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -215,6 +215,22 @@ class TestRedirect(BaseRedirectTest):
                 response = self.client.get(pages[1].get_absolute_url().rstrip('/'))
             self.assertRedirects(response, redirect.new_path, status_code=301)
 
+    def test_redirect_no_append_slash_quoted(self):
+        pages = self.get_pages()
+
+        original_path = '/path%20(escaped)/'
+        with override_settings(APPEND_SLASH=False):
+            redirect = Redirect.objects.create(
+                site=self.site_1,
+                old_path=original_path,
+                new_path=pages[0].get_absolute_url(),
+                response_code='301',
+            )
+
+            with self.assertNumQueries(5):
+                response = self.client.get(original_path.rstrip('/'))
+            self.assertRedirects(response, redirect.new_path, status_code=301)
+
     def test_redirect_no_append_slash_no_match(self):
         pages = self.get_pages()
 

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -22,6 +22,18 @@ class TestRedirect(BaseRedirectTest):
                 'parent': 'test-page'}},
     )
 
+    def test_str(self):
+        pages = self.get_pages()
+
+        redirect = Redirect.objects.create(
+            site=self.site_1,
+            old_path=pages[1].get_absolute_url(),
+            new_path=pages[0].get_absolute_url(),
+            response_code='301',
+        )
+        self.assertIn(pages[1].get_absolute_url(), force_text(redirect))
+        self.assertIn(pages[0].get_absolute_url(), force_text(redirect))
+
     def test_301_redirect(self):
         pages = self.get_pages()
 


### PR DESCRIPTION
If URL contains quoted chars, we need to unquote the path before matching (and viceversa)

Add minor refactoring to test multiple redirects in a loop