### PR TITLE
Minor cache key generation logic and docs refactoring

### DIFF
--- a/djangocms_redirect/utils.py
+++ b/djangocms_redirect/utils.py
@@ -3,10 +3,13 @@ import hashlib
 
 
 def get_key_from_path_and_site(path, site_id):
-    '''
-    cache key has to be < 250 chars to avoid memcache.Client.MemcachedKeyLengthError
-    The best algoritm is SHA-224 whose output (224 chars) respects this limitations
-    '''
-    key = '{}_{}'.format(path, site_id)
-    key = hashlib.sha224(key.encode('utf-8')).hexdigest()
+    """
+    cache key has to be < 250 chars to avoid memcache.Client.MemcachedKeyLengthError.
+
+    SHA-224 is the best algorithm whose output (224 chars) respects this limitations:
+
+    total key length: Prefix (11) + HASH (224) + ID (max 3) + 2 separators (2) = 240
+    """
+    hashed_path = hashlib.sha224(path.encode('utf-8')).hexdigest()
+    key = 'CMSREDIRECT:{}:{}'.format(hashed_path, site_id)
     return key


### PR DESCRIPTION
Common prefix allows to invalidate all the keys at once, for backends that allows fetching by prefix