### PR TITLE
Add "subpath_match" and "catchall_redirect" Redirect settings to Django admin.

### DIFF
--- a/djangocms_redirect/admin.py
+++ b/djangocms_redirect/admin.py
@@ -10,7 +10,14 @@ from .utils import normalize_url
 class RedirectForm(ModelForm):
     class Meta:
         model = Redirect
-        fields = ["site", "old_path", "new_path", "response_code"]
+        fields = [
+            "site",
+            "old_path",
+            "new_path",
+            "response_code",
+            "subpath_match",
+            "catchall_redirect"
+        ]
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -25,7 +32,13 @@ class RedirectForm(ModelForm):
 
 @admin.register(Redirect)
 class RedirectAdmin(admin.ModelAdmin):
-    list_display = ("old_path", "new_path", "response_code")
+    list_display = (
+        "old_path",
+        "new_path",
+        "response_code",
+        "subpath_match",
+        "catchall_redirect"
+    )
     list_filter = ("site",)
     search_fields = ("old_path", "new_path")
     radio_fields = {"site": admin.VERTICAL}


### PR DESCRIPTION
The subpath_match and catchall_redirect settings exist on the Redirect object model, but they are not displayed on the django admin interface.