### PR TITLE
Add missing fields in admin

### DIFF
--- a/changes/44.feature
+++ b/changes/44.feature
@@ -1,0 +1,1 @@
+Add missing subpath_match and catchall_redirect fields in admin

--- a/djangocms_redirect/admin.py
+++ b/djangocms_redirect/admin.py
@@ -10,7 +10,7 @@ from .utils import normalize_url
 class RedirectForm(ModelForm):
     class Meta:
         model = Redirect
-        fields = ["site", "old_path", "new_path", "response_code"]
+        fields = ["site", "old_path", "new_path", "response_code", "subpath_match", "catchall_redirect"]
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -25,7 +25,7 @@ class RedirectForm(ModelForm):
 
 @admin.register(Redirect)
 class RedirectAdmin(admin.ModelAdmin):
-    list_display = ("old_path", "new_path", "response_code")
+    list_display = ("old_path", "new_path", "response_code", "subpath_match", "catchall_redirect")
     list_filter = ("site",)
     search_fields = ("old_path", "new_path")
     radio_fields = {"site": admin.VERTICAL}


### PR DESCRIPTION
# Description

Add missing subpath_match and catchall_redirect fields in admin 

## References

Fix #44 

# Checklist

* [x] I have read the [contribution guide](https://djangocms-redirect.readthedocs.io/en/latest/contributing.html)
* [x] Code lint checked via `inv lint`
* [x] ``changes`` file included (see [docs](https://djangocms-redirect.readthedocs.io/en/latest/contributing.html#pull-request-guidelines))
* [ ] Usage documentation added in case of new features
* [ ] Tests added
