### PR TITLE
fix: pin ruff version to 0.15.22

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,7 @@ repos:
     hooks:
       - id: black
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: 'v0.15.20'
+    rev: 'v0.15.22'
     hooks:
       - id: ruff
   - repo: https://github.com/asottile/pyupgrade
@@ -46,5 +46,4 @@ repos:
         pass_filenames: false
         always_run: true
 ci:
-  skip:
-    - towncrier
+  skip: [towncrier,ruff]

--- a/changes/146.bugfix
+++ b/changes/146.bugfix
@@ -1,0 +1,1 @@
+Pin ruff version to 0.15.22

--- a/tox.ini
+++ b/tox.ini
@@ -30,7 +30,7 @@ commands =
     {envpython} -minterrogate -c pyproject.toml djangocms_redirect tests
 deps =
     interrogate
-    ruff
+    ruff~=0.15.22
 skip_install = true
 
 [testenv:isort]


### PR DESCRIPTION
# Description

Pin ruff version to 0.15.22

## References

Fix #146 

# Checklist

* [x] I have read the [contribution guide](https://djangocms-redirect.readthedocs.io/en/latest/contributing.html)
* [ ] Code lint checked via `inv lint`
* [x] ``changes`` file included (see [docs](https://djangocms-redirect.readthedocs.io/en/latest/contributing.html#pull-request-guidelines))
* [ ] Usage documentation added in case of new features
* [ ] Tests added
